### PR TITLE
Fix wave parameter assignment in sceneCreate

### DIFF
--- a/scene/sceneCreate.m
+++ b/scene/sceneCreate.m
@@ -412,7 +412,7 @@ switch sceneName
         scene = sceneSweep(scene,sz,maxFreq,wave,yContrast);
         parms.sz = sz;
         parms.maxFreq = maxFreq;
-        parms.wave = varargin{3};
+        parms.wave = wave;
 
     case {'ramp','linearintensityramp','rampequalphoton'}
         % scene = sceneCreate('ramp',sz,dynamicRange);


### PR DESCRIPTION
Previously, `params.wave = varargin{3}` raises an error if no default values are given, since by default length(varargin)=0.